### PR TITLE
Support Processing >= 3.0

### DIFF
--- a/wangTiles/wangTiles.pde
+++ b/wangTiles/wangTiles.pde
@@ -18,15 +18,14 @@ PImage tilesImage;
 HashMap<Tile, Integer> tileToNum= new HashMap<Tile, Integer>();
 
 void settings(){
-
+  final int windowWidth = tileWidth * mapWidth;
+  size(windowWidth, windowWidth);
   //noSmooth();
 //  smooth(4);
 
 }
 
 void setup() {
-  final int windowWidth = tileWidth * mapWidth;
-  size(windowWidth, windowWidth);
   tilesImage = loadImage(FILENAME);
   wangTiles = parseTilesIntoSet();
 


### PR DESCRIPTION
**Problem being solved:**
Code would not run under Processing >= 3.0 as size() with variable parameters in setup() is no longer allowed as of Processing 3.0. (Reference: https://processing.org/reference/size_.html)

**Changes:**
Moved the size() method from setup to settings 

**Testing**
Tested via running wangTiles.pde under Processing 4.0b2. 
Appears to produce expected results without error.